### PR TITLE
Fix crash on launch with Java 12+.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ license {
 
 minecraft {
     mappings channel: 'snapshot', version: '20201028-1.16.3'
+    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
     runs {
         client {
             workingDirectory project.file('run')

--- a/src/main/java/me/shedaniel/istations/ImprovedStations.java
+++ b/src/main/java/me/shedaniel/istations/ImprovedStations.java
@@ -28,16 +28,12 @@ import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.RegistryObject;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Set;
 
 @Mod.EventBusSubscriber(modid = "improved-stations", bus = Mod.EventBusSubscriber.Bus.MOD)
 @Mod("improved-stations")
@@ -90,18 +86,9 @@ public class ImprovedStations {
     }
     
     private static void applyMoreBlocks(TileEntityType<?> type, Block... blocks) {
-        try {
-            Field field = ObfuscationReflectionHelper.findField(TileEntityType.class, "field_223046_I");
-            field.setAccessible(true);
-            ArrayList<Block> list = Lists.newArrayList((Set<Block>) field.get(type));
-            list.addAll(Arrays.asList(blocks));
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
-            modifiersField.setAccessible(true);
-            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-            field.set(type, ImmutableSet.copyOf(list));
-        } catch (Throwable throwable) {
-            throw new RuntimeException(throwable);
-        }
+        ArrayList<Block> list = Lists.newArrayList(type.validBlocks);
+        list.addAll(Arrays.asList(blocks));
+        type.validBlocks = ImmutableSet.copyOf(list);
     }
     
     public static void rightClickBlock(PlayerInteractEvent.RightClickBlock event) {

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,1 @@
+public-f net.minecraft.tileentity.TileEntityType field_223046_I # validBlocks


### PR DESCRIPTION
After Java 12, `Field.modifiers` was added to [`Reflection.fieldFilterMap`](https://github.com/AdoptOpenJDK/openjdk-jdk12u/blob/184fdaae009a148259ece4131c4a29d284d69f51/src/java.base/share/classes/jdk/internal/reflect/Reflection.java#L57) so that we cannot modify it by using reflection.

We should use AT instead of reflection.

crash report: https://paste.ubuntu.com/p/Df5FGJ8czV/